### PR TITLE
Fix build issues for Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,15 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@types/react-router-dom": "^5.3.3",
+    "@types/node": "^20.12.7",
     "@vitejs/plugin-react": "^4.3.1",
     "eslint": "^9.9.0",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -27,12 +27,12 @@ interface NavItemProps {
   onClick?: () => void;
 }
 
-function NavItem({ to, label, onClick }: NavItemProps) {
+const NavItem: React.FC<NavItemProps> = ({ to, label, onClick }) => {
   return (
     <NavLink
       to={to}
       onClick={onClick}
-      className={({ isActive }) =>
+      className={({ isActive }: { isActive: boolean }) =>
         `block px-3 py-2 rounded-md text-sm font-medium transition-colors ${
           isActive ? "bg-blue-600 text-white" : "text-gray-700 hover:text-blue-600"
         }`
@@ -41,11 +41,11 @@ function NavItem({ to, label, onClick }: NavItemProps) {
       {label}
     </NavLink>
   );
-}
+};
 
 export default function Header() {
   const [open, setOpen] = useState(false);
-  const toggle = () => setOpen((o) => !o);
+  const toggle = () => setOpen((o: boolean) => !o);
   const close = () => setOpen(false);
 
   const navItems = [

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -13,6 +13,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "types": ["node"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -11,6 +11,7 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "types": ["node"],
 
     /* Linting */
     "strict": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary
- add react-router-dom and type dependencies
- support node alias resolution in Vite config
- type NavLink active state and state updater
- include Node types in tsconfigs

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6865f76d4f08832ba3a11ecd6e64c02f