### PR TITLE
feat: add custom logo and dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,16 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Shadcn Example</title>
+    <script>
+      tailwind.config = { darkMode: "class" };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
-  <body class="min-h-screen bg-gray-50">
+  <body class="min-h-screen bg-gray-900 text-gray-100">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#1a1a1a"/>
+  <circle cx="44" cy="12" r="10" fill="#f6ad1a"/>
+  <path d="M44 8c2 4 4 6 4 8a4 4 0 11-8 0c0-2 2-4 4-8z" fill="#111"/>
+  <path d="M8 28c0-6 6-10 14-10h22l4-6h4l4 6c6 0 10 6 10 12v8h-4l-4 6h-4l-4-6H26l-4 6h-4l-4-6h-6z" fill="none" stroke="#d4b06a" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="20" cy="36" r="3" fill="#d4b06a"/>
+</svg>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -32,16 +32,16 @@ const NavItem: React.FC<NavItemProps> = ({ to, label, onClick }) => {
     <NavLink
       to={to}
       onClick={onClick}
-      className={({ isActive }: { isActive: boolean }) =>
-        `block px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-          isActive ? "bg-blue-600 text-white" : "text-gray-700 hover:text-blue-600"
-        }`
-      }
-    >
-      {label}
-    </NavLink>
-  );
-};
+        className={({ isActive }: { isActive: boolean }) =>
+          `block px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+            isActive ? "bg-blue-600 text-white" : "text-gray-300 hover:text-white"
+          }`
+        }
+      >
+        {label}
+      </NavLink>
+    );
+  };
 
 export default function Header() {
   const [open, setOpen] = useState(false);
@@ -55,12 +55,12 @@ export default function Header() {
     { to: "/DD", label: "DD" },
   ];
 
-  return (
-    <header className="border-b h-14 flex items-center sticky top-0 bg-white z-50">
-      <div className="container mx-auto flex items-center justify-between px-4">
-        <Link to="/" className="font-bold text-lg" onClick={close}>
-          LOGO
-        </Link>
+    return (
+      <header className="border-b border-gray-700 h-14 flex items-center sticky top-0 bg-gray-900 z-50">
+        <div className="container mx-auto flex items-center justify-between px-4">
+          <Link to="/" className="font-bold text-lg text-white" onClick={close}>
+            <img src="/logo.svg" alt="Logo" className="h-8 w-auto" />
+          </Link>
 
         <nav className="hidden md:flex gap-4">
           {navItems.map((item) => (
@@ -68,20 +68,20 @@ export default function Header() {
           ))}
         </nav>
 
-        <Button
-          variant="outline"
-          size="icon"
-          className="md:hidden"
-          onClick={toggle}
-          aria-label={open ? "关闭菜单" : "打开菜单"}
-        >
+          <Button
+            variant="outline"
+            size="icon"
+            className="md:hidden text-gray-100 border-gray-700"
+            onClick={toggle}
+            aria-label={open ? "关闭菜单" : "打开菜单"}
+          >
           {open ? <XIcon className="h-5 w-5" /> : <MenuIcon className="h-5 w-5" />}
         </Button>
       </div>
 
-      {open && (
-        <div className="md:hidden absolute top-14 inset-x-0 border-b bg-white shadow-sm">
-          <nav className="flex flex-col py-2">
+        {open && (
+          <div className="md:hidden absolute top-14 inset-x-0 border-b border-gray-700 bg-gray-900 shadow-sm">
+            <nav className="flex flex-col py-2">
             {navItems.map((item) => (
               <NavItem key={item.to} {...item} onClick={close} />
             ))}


### PR DESCRIPTION
## Summary
- add custom piggy bank logo and use it as favicon
- enable Tailwind dark mode and apply dark styling
- update header navigation for dark theme

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b647c04a94832b825b659fc87babe4