### PR TITLE
feat: add site name after logo

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -58,8 +58,13 @@ export default function Header() {
     return (
       <header className="border-b border-gray-700 h-14 flex items-center sticky top-0 bg-gray-900 z-50">
         <div className="container mx-auto flex items-center justify-between px-4">
-          <Link to="/" className="font-bold text-lg text-white" onClick={close}>
+          <Link
+            to="/"
+            className="flex items-center font-bold text-lg text-yellow-400"
+            onClick={close}
+          >
             <img src="/logo.png" alt="Logo" className="h-13 w-auto" />
+            <span className="ml-2">Savings game</span>
           </Link>
 
         <nav className="hidden md:flex gap-4">


### PR DESCRIPTION
## Summary
- show golden "Savings game" text after header logo

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b64d21f9d8832bb710cc2a48036e06