### PR TITLE
fix: remove unused React import

### DIFF
--- a/src/components/FooterTable.tsx
+++ b/src/components/FooterTable.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 interface Row {
   time: string;
   player: string;


### PR DESCRIPTION
## Summary
- drop unused React import in FooterTable

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b796384824832ba76b9cd271ed252f