### PR TITLE
feat: make footer table responsive

### DIFF
--- a/src/components/FooterTable.tsx
+++ b/src/components/FooterTable.tsx
@@ -21,8 +21,8 @@ const rows: Row[] = Array.from({ length: 30 }, () => ({
 export default function FooterTable() {
   return (
     <footer className="border-t border-gray-700 p-4">
-      <div className="container mx-auto overflow-x-auto">
-        <table className="min-w-full text-sm text-left text-gray-300">
+      <div className="w-full overflow-x-auto">
+        <table className="w-full text-xs text-left text-gray-300">
           <thead className="text-xs uppercase bg-gray-800 text-gray-400">
             <tr>
               <th className="px-4 py-2">Time</th>


### PR DESCRIPTION
## Summary
- make FooterTable span full screen width
- shrink footer table typography for better fit

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b797451a0c832bafdb9b3fa23f7c9d