### PR TITLE
Enlarge item cards and use two-column layout

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,13 +8,13 @@ type ItemID = typeof items[number];
 
 export default function Home() {
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+    <div className="grid grid-cols-2 gap-6">
       {items.map((id: ItemID) => (
-        <Card key={id} className="flex flex-col items-center text-center">
+        <Card key={id} className="flex flex-col items-center text-center h-64">
           <CardHeader>{id}</CardHeader>
           <CardContent>
-            <Link to={`/${id}`}> 
-              <Button className="w-28">打开 {id}</Button>
+            <Link to={`/${id}`}>
+              <Button className="w-56 h-20">打开 {id}</Button>
             </Link>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- Double size of item cards AA, BB, CC, DD by enlarging buttons and card height
- Switch home page grid to two columns for a two-item-per-row layout

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba2b1e502c832ba87f7e7e6cbd644f