### PR TITLE
style: center buttons on green home cards

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -10,11 +10,14 @@ export default function Home() {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
       {items.map((id: ItemID) => (
-        <Card key={id} className="flex flex-col items-center text-center h-64">
+        <Card
+          key={id}
+          className="flex flex-col justify-between items-center text-center h-64 bg-green-500"
+        >
           <CardHeader>{id}</CardHeader>
-          <CardContent className="w-full">
+          <CardContent className="w-full flex justify-center">
             <Link to={`/${id}`}>
-              <Button className="w-full h-20">打开 {id}</Button>
+              <Button className="w-32">打开 {id}</Button>
             </Link>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- style home cards with green background
- center the open buttons at the bottom with a fixed width

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be2495b140832b86387d8839524d60