### PR TITLE
fix: set home tiles to green background

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -12,7 +12,7 @@ export default function Home() {
       {items.map((id: ItemID) => (
         <Card
           key={id}
-          className="flex flex-col justify-between items-center text-center h-64 bg-green-500"
+          className="flex flex-col justify-between items-center text-center h-64 !bg-green-500"
         >
           <CardHeader>{id}</CardHeader>
           <CardContent className="w-full flex justify-center">


### PR DESCRIPTION
## Summary
- ensure home tiles use a green background

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be260eedec832b882c3568979b2b68